### PR TITLE
Adding node-uuid lib

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -18,4 +18,7 @@ var app = new EmberAddon();
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
 
+// node-uuid
+app.import('bower_components/node-uuid/uuid.js');
+
 module.exports = app.toTree();

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Utils:
 
 + `guid`
 + `titleize`
++ `node-uuid`

--- a/addon/utils/uuid.js
+++ b/addon/utils/uuid.js
@@ -1,0 +1,20 @@
+/*
+ * UUID generation
+ */
+
+//type - optional, random-based by default. Possible values are 'time-based' or 'random' 
+export function generateUUID(type) {
+  if (type === 'time') {
+    return _generateTimebasedUUID();
+  } else {
+    return _generateRandomUUID();
+  }
+}
+
+function _generateTimebasedUUID() {
+  return uuid.v1();
+}
+
+function _generateRandomUUID() {
+  return uuid.v4();
+}

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
+    "node-uuid": "~1.4.3",
     "qunit": "~1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-shared-libs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Shared utils/libraries",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
After considering the option of the generated UUID based on the random function, a couple of us are leaning to using node-uuid instead. There are concerns about lack of tests surrounding the random function, as well as compliance for UUID generation. Then there is the standardization from the part of the back end that will be consuming the UUID and their need for a common agreement between the client and server for this. Some discussion around this can be found in the comments  here:

https://github.com/Ticketfly/event-management-web/pull/13

In addition to providing the client options for their UUID needs, node-uuid comes with a time-based version of the UUID (a.k.a. v1) and a random generated version (v4). 

@Ticketfly/frontenders
