### PR TITLE
Adding normalizeEntityName function

### DIFF
--- a/blueprints/frontend-shared-libs/index.js
+++ b/blueprints/frontend-shared-libs/index.js
@@ -2,6 +2,8 @@
 
 module.exports = {
   name: 'frontend-shared-libs',
+  
+  normalizeEntityName: function() {  },
     
   beforeInstall: function() {
     return this.addBowerPackageToProject('node-uuid', '~1.4.3');


### PR DESCRIPTION
```
normalizeEntityName: function() {
    // this prevents an error when the entityName is
    // not specified (since that doesn't actually matter
    // to us
  },
```
